### PR TITLE
Add FastAPI quiz backend

### DIFF
--- a/quiz_api.py
+++ b/quiz_api.py
@@ -1,0 +1,153 @@
+from typing import Optional, Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from student_manager import StudentManager, SessionExpiredError
+from main import (
+    load_chapter_map,
+    extract_text_with_metadata,
+    split_documents,
+    create_and_save_vectorstore,
+    load_retriever_and_reranker,
+    generate_question_from_chapter_content,
+    get_feedback_on_answer,
+    VECTORSTORE_PATH,
+    PDF_PATH,
+    CHAPTER_MAP_PATH,
+)
+from langchain_community.embeddings import HuggingFaceBgeEmbeddings
+from langchain_openai import ChatOpenAI
+
+app = FastAPI(title="Quiz API")
+
+student_mgr = StudentManager()
+
+# Global resources
+embeddings = HuggingFaceBgeEmbeddings(
+    model_name="BAAI/bge-base-en-v1.5",
+    model_kwargs={"device": "cpu"},
+    encode_kwargs={"normalize_embeddings": True},
+)
+llm = ChatOpenAI(model_name="gpt-4.1-nano", temperature=0.7, max_tokens=1500)
+retrievers: Dict[str, any] = {}
+
+
+class LoginRequest(BaseModel):
+    student_id: str
+    name: Optional[str] = None
+
+
+class QuestionRequest(BaseModel):
+    student_id: str
+    chapter_title: str
+
+
+class AnswerRequest(BaseModel):
+    student_id: str
+    question: str
+    expected_answer: str
+    user_answer: str
+
+
+def ensure_vectorstore():
+    if not VECTORSTORE_PATH.exists():
+        chapters = load_chapter_map(CHAPTER_MAP_PATH)
+        docs = extract_text_with_metadata(PDF_PATH, chapters)
+        chunks = split_documents(docs)
+        create_and_save_vectorstore(chunks)
+
+
+def get_retriever(chapter_id: str):
+    if chapter_id not in retrievers:
+        ensure_vectorstore()
+        retrievers[chapter_id] = load_retriever_and_reranker(
+            embeddings,
+            embeddings.query_instruction,
+            chapter_id,
+        )
+    return retrievers[chapter_id]
+
+
+@app.post("/login")
+def login(req: LoginRequest):
+    student = student_mgr.db.get_student(req.student_id)
+    if student:
+        session = student_mgr.create_session(
+            student_id=req.student_id,
+            student_name=student["student_name"],
+            initial_zpd=student["zpd_score"],
+        )
+    else:
+        if not req.name:
+            raise HTTPException(400, "Student not found. Provide name to register.")
+        student_mgr.db.add_student(req.student_id, req.name, 5.0)
+        session = student_mgr.create_session(
+            student_id=req.student_id,
+            student_name=req.name,
+            initial_zpd=5.0,
+        )
+    return {"student_name": session.student_name, "zpd": session.current_zpd}
+
+
+@app.get("/chapters")
+def chapters():
+    return load_chapter_map(CHAPTER_MAP_PATH)
+
+
+@app.post("/generate-question")
+def generate_question(req: QuestionRequest):
+    session = student_mgr.get_session(req.student_id)
+    if not session:
+        raise HTTPException(401, "Invalid or expired session")
+    chapter_map = load_chapter_map(CHAPTER_MAP_PATH)
+    chapter_id = "all"
+    for c in chapter_map:
+        if c["title"] == req.chapter_title:
+            chapter_id = c["id"]
+            break
+    retriever = get_retriever(chapter_id)
+    question, answer, _ = generate_question_from_chapter_content(
+        retriever=retriever,
+        llm=llm,
+        selected_chapter_title=req.chapter_title,
+        previous_questions=set(),
+        zpd_score=session.current_zpd,
+    )
+    return {"question": question, "expected_answer": answer}
+
+
+@app.post("/submit-answer")
+def submit_answer(req: AnswerRequest):
+    session = student_mgr.get_session(req.student_id)
+    if not session:
+        raise HTTPException(401, "Invalid or expired session")
+    feedback, correct, analysis = get_feedback_on_answer(
+        user_answer=req.user_answer,
+        expected_answer=req.expected_answer,
+        question=req.question,
+        llm=llm,
+        context="",
+        zpd_score=session.current_zpd,
+    )
+    try:
+        old, new = student_mgr.update_student_zpd(
+            student_session=session,
+            is_correct=correct,
+            is_partial=analysis.get("partially_correct", False),
+        )
+    except SessionExpiredError:
+        raise HTTPException(401, "Session expired. Please log in again.")
+    return {
+        "feedback": feedback,
+        "correct": correct,
+        "hint": analysis.get("hint"),
+        "old_zpd": old,
+        "new_zpd": new,
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("quiz_api:app", host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,20 @@
-# Core dependencies
 python-dotenv>=1.0.0
-
-# LangChain and related - updated versions for compatibility
 langchain>=0.1.0
 langchain-community>=0.0.20
 langchain-openai>=0.0.5
 langchain-huggingface>=0.0.1
-
-# Document processing
-PyMuPDF>=1.23.0  # Provides 'fitz' module
-
-# Vector stores and embeddings
-faiss-cpu>=1.7.4  # Use faiss-gpu if you have CUDA
+PyMuPDF>=1.23.0
+faiss-cpu>=1.7.4
 sentence-transformers>=2.2.2
-
-# PyTorch - specify version compatible with your system
 torch>=2.0.0
 transformers>=4.30.0
 huggingface-hub>=0.16.0
-
-# Utilities
 tqdm>=4.65.0
 numpy>=1.24.0
-# pydantic>=2.0.0
-
-# OpenAI
 tiktoken>=0.5.0
 openai>=1.0.0
-
-# Additional dependencies that might be needed
 accelerate>=0.20.0
 safetensors>=0.3.0
-
-
 fastapi==0.68.0
 uvicorn==0.15.0
 sqlalchemy==1.4.23
@@ -40,3 +22,4 @@ python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.5
 pydantic==1.8.2
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,154 @@
+import streamlit as st
+
+from student_manager import StudentManager
+from main import (
+    load_chapter_map,
+    extract_text_with_metadata,
+    split_documents,
+    create_and_save_vectorstore,
+    load_retriever_and_reranker,
+    setup_qa_chain,
+    generate_question_from_chapter_content,
+    get_feedback_on_answer,
+    VECTORSTORE_PATH,
+    PDF_PATH,
+    CHAPTER_MAP_PATH,
+)
+from langchain_community.embeddings import HuggingFaceBgeEmbeddings
+from langchain_openai import ChatOpenAI
+
+st.set_page_config(page_title="History Tutor")
+student_mgr = StudentManager()
+
+
+def login():
+    st.title("History Tutor")
+    student_id = st.text_input("Student ID")
+    if st.button("Login") and student_id:
+        student = student_mgr.db.get_student(student_id)
+        if student:
+            session = student_mgr.create_session(
+                student_id=student_id,
+                student_name=student["student_name"],
+                initial_zpd=student["zpd_score"],
+            )
+        else:
+            st.session_state["register_id"] = student_id
+            st.session_state["login_step"] = "register"
+            return
+        st.session_state["session"] = session
+        st.session_state["login_step"] = "select_chapter"
+
+
+def register():
+    st.title("Register Student")
+    name = st.text_input("Name")
+    if st.button("Create") and name:
+        student_id = st.session_state.get("register_id")
+        student_mgr.db.add_student(student_id, name, 5.0)
+        session = student_mgr.create_session(
+            student_id=student_id,
+            student_name=name,
+            initial_zpd=5.0,
+        )
+        st.session_state["session"] = session
+        st.session_state["login_step"] = "select_chapter"
+
+
+def select_chapter():
+    st.header(f"Welcome, {st.session_state['session'].student_name}")
+    chapters = load_chapter_map(CHAPTER_MAP_PATH)
+    chapter_titles = [c["title"] for c in chapters]
+    options = ["All Chapters"] + chapter_titles
+    choice = st.selectbox("Choose chapter", options)
+    if st.button("Start"):
+        st.session_state["selected_chapter"] = choice
+        st.session_state["login_step"] = "quiz"
+        initialize_qa(choice, chapters)
+
+
+def initialize_qa(choice, chapters):
+    if choice != "All Chapters":
+        idx = [c["title"] for c in chapters].index(choice)
+        selected_id = chapters[idx]["id"]
+    else:
+        selected_id = "all"
+
+    if not VECTORSTORE_PATH.exists():
+        docs = extract_text_with_metadata(PDF_PATH, chapters)
+        chunks = split_documents(docs)
+        create_and_save_vectorstore(chunks)
+
+    embeddings = HuggingFaceBgeEmbeddings(
+        model_name="BAAI/bge-base-en-v1.5",
+        model_kwargs={"device": "cpu"},
+        encode_kwargs={"normalize_embeddings": True},
+    )
+    retriever = load_retriever_and_reranker(
+        embeddings, embeddings.query_instruction, selected_id
+    )
+    llm = ChatOpenAI(model_name="gpt-4.1-nano", temperature=0.7, max_tokens=1500)
+    qa_chain = setup_qa_chain(llm, retriever)
+
+    st.session_state["retriever"] = retriever
+    st.session_state["llm"] = llm
+    st.session_state["qa_chain"] = qa_chain
+    st.session_state["asked"] = set()
+
+
+def quiz():
+    session = st.session_state["session"]
+    llm = st.session_state["llm"]
+    retriever = st.session_state["retriever"]
+    chapter_title = st.session_state.get("selected_chapter", "All Chapters")
+    asked = st.session_state["asked"]
+
+    if "current_question" not in st.session_state:
+        q, a, _ = generate_question_from_chapter_content(
+            retriever=retriever,
+            llm=llm,
+            selected_chapter_title=chapter_title,
+            previous_questions=asked,
+            zpd_score=session.current_zpd,
+        )
+        st.session_state["current_question"] = q
+        st.session_state["expected_answer"] = a
+        asked.add(q.lower())
+
+    st.write(f"**Question:** {st.session_state['current_question']}")
+    answer = st.text_input("Your answer", key="answer")
+    if st.button("Submit") and answer:
+        feedback, correct, analysis = get_feedback_on_answer(
+            user_answer=answer,
+            expected_answer=st.session_state["expected_answer"],
+            question=st.session_state["current_question"],
+            llm=llm,
+            context="",
+            zpd_score=session.current_zpd,
+        )
+        old, new = student_mgr.update_student_zpd(
+            student_session=session,
+            is_correct=correct,
+            is_partial=analysis.get("partially_correct", False),
+        )
+        st.write(feedback)
+        if not correct and analysis.get("hint"):
+            if st.button("Hint"):
+                st.info(analysis["hint"])
+        st.write(f"ZPD: {old:.1f} -> {new:.1f}")
+        del st.session_state["current_question"]
+        st.experimental_rerun()
+    if st.button("New Question"):
+        del st.session_state["current_question"]
+        st.experimental_rerun()
+
+
+step = st.session_state.get("login_step", "login")
+if step == "login":
+    login()
+elif step == "register":
+    register()
+elif step == "select_chapter":
+    select_chapter()
+else:
+    quiz()


### PR DESCRIPTION
## Summary
- implement `quiz_api.py` to expose login, question generation and answer evaluation endpoints via FastAPI
- use existing `main.py` logic for generating questions, hints and answer feedback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc7960fbc83248fc4660e70d91349